### PR TITLE
Update exercise5.py

### DIFF
--- a/learning_python/lesson3/exercise5.py
+++ b/learning_python/lesson3/exercise5.py
@@ -65,7 +65,7 @@ print()
 print('-' * 80)
 for ip_addr in ip_list:
     print("IP Addr: ", ip_addr)
-    return_code = os.system("ping -c 3 {}".format(ip_addr))
+    return_code = os.system("{} {}".format(base_cmd, ip_addr))
     print('-' * 80)
 print('-' * 80)
 print()


### PR DESCRIPTION
The base_cmd var is taking different value based on the WINDOWS var. It make sense to use base_cmd var later in the code instead of hard-code the "ping" command.